### PR TITLE
adding nav service

### DIFF
--- a/app/assets/javascripts/angular/controllers/BeerIndexCtrl.js
+++ b/app/assets/javascripts/angular/controllers/BeerIndexCtrl.js
@@ -1,10 +1,7 @@
-beery.controller('BeerIndexCtrl', ['$scope', '$location', '$http', function($scope, $location, $http) {
+beery.controller('BeerIndexCtrl', ['$scope', '$http', 'nav', function($scope, $http, nav) {
   $scope.beers = [];
   $http.get('./beers.json').success(function(data) {
     $scope.beers = data;
   });
-
-  $scope.viewBeer = function(id) {
-    $location.url('/beers/'+id);
-  };
+  $scope.nav = nav;
 }]);

--- a/app/assets/javascripts/angular/controllers/BeerShowCtrl.js
+++ b/app/assets/javascripts/angular/controllers/BeerShowCtrl.js
@@ -1,6 +1,9 @@
-beery.controller('BeerShowCtrl', ['$scope', '$http', '$routeParams', function($scope, $http, $routeParams) {
-  $http.get("./beers/"+$routeParams.id+".json").success(function(data) {
-    console.log(data);
-    $scope.beer = data;
-  });
-}]);
+beery.controller('BeerShowCtrl', ['$scope', '$http', '$routeParams', 'nav', 
+  function($scope, $http, $routeParams, nav) {
+    $http.get("./beers/"+$routeParams.id+".json").success(function(data) {
+      console.log(data);
+      $scope.beer = data;
+    });
+    $scope.nav = nav;
+  }
+]);

--- a/app/assets/javascripts/angular/controllers/HomeCtrl.js
+++ b/app/assets/javascripts/angular/controllers/HomeCtrl.js
@@ -1,3 +1,4 @@
-beery.controller('HomeCtrl', ['$scope', function($scope) {
+beery.controller('HomeCtrl', ['$scope', 'nav', function($scope, nav) {
   $scope.title = 'Beery: Beer Tracker';
+  $scope.nav = nav;
 }]);

--- a/app/assets/javascripts/main.js
+++ b/app/assets/javascripts/main.js
@@ -18,4 +18,32 @@ window.beery = angular.module('beery', ['ngRoute']).
         templateUrl: '/assets/templates/beers/show.html',
         controller: 'BeerShowCtrl'
       });
-    }]);
+    }]).
+  factory('nav', ['$location', function($location) {
+    return {
+      viewHome: function() {
+        $location.url('/');
+      },
+      viewBeer: function(id) {
+        $location.url('/beers/' + id);
+      },
+      viewBeers: function() {
+        $location.url('/beers/');
+      },
+      viewNewBeer: function() {
+        $location.url('/brewer');
+      },
+      viewBrewer: function(id) {
+        $location.url('/brewers/' + id);
+      },
+      viewBrewers: function() {
+        $location.url('/brewers');
+      },
+      viewNewBrewer: function() {
+        $location.url('/brewer');
+      },
+      viewUsers: function() {
+        $location.url('/users');
+      }
+    };
+  }]);

--- a/app/assets/javascripts/templates/beers/index.html.haml
+++ b/app/assets/javascripts/templates/beers/index.html.haml
@@ -1,4 +1,4 @@
-%a{:href => "/#"}
+%a{:'ng-click' => "nav.viewHome()"}
   ="Home"
 %table
   %thead
@@ -13,7 +13,7 @@
         %strong Country
   %tr{:'ng-repeat' => "beer in beers"}
     %td.name
-      %a{:'ng-click' => "viewBeer(beer.id)"}
+      %a{:'ng-click' => "nav.viewBeer(beer.id)"}
         {{ beer.name }}
     %td.brewer {{ beer.brewer.name }}
     %td.style {{ beer.style.name }}

--- a/app/assets/javascripts/templates/beers/show.html.haml
+++ b/app/assets/javascripts/templates/beers/show.html.haml
@@ -1,2 +1,2 @@
-%a{:href => '#/beers'} Beers
+%a{:'ng-click' => "nav.viewBeers()"} Beers
 %h1 {{beer.name}}

--- a/app/assets/javascripts/templates/home.html.haml
+++ b/app/assets/javascripts/templates/home.html.haml
@@ -1,8 +1,8 @@
 %h1 {{title}}
 %ul
   %li
-    %a{:href => '/#/beers'} Beers
+    %a{:'ng-click' => 'nav.viewBeers()'} Beers
   %li
-    %a{:href => '/#/users'} Users
+    %a{:'ng-click' => 'nav.viewUsers()'} Users
   %li
-    %a{:href => '/#/brewers'} Brewers
+    %a{:'ng-click' => 'nav.viewBrewers()'} Brewers


### PR DESCRIPTION
@holtbp @rantler 

Not sure if there's a better way to do this, but having a `nav` service seems like it would solve the problem of redefining the same navigation functions.

Any controller/view that has an `ng-click` will need to inject the nav service and then add it to the `$scope` like `$scope.nav = nav;`. Maybe there are convenience methods of `$scope` that I'm not aware of?
